### PR TITLE
Redesign landing page, fix resume typos, add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build static site
+        run: |
+          mkdir -p _site/static
+          mkdir -p _site/resume
+
+          # Pages
+          cp tribone/templates/index.html _site/index.html
+          cp tribone/templates/resume.html _site/resume/index.html
+
+          # Assets
+          cp -r tribone/static/css   _site/static/css
+          cp -r tribone/static/fonts _site/static/fonts
+          cp -r tribone/static/img   _site/static/img
+          cp    tribone/static/favicon.ico _site/favicon.ico
+          cp    tribone/static/resume.pdf  _site/resume.pdf
+
+          # Custom domain
+          echo "trib.one" > _site/CNAME
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/tribone/static/css/index.css
+++ b/tribone/static/css/index.css
@@ -1,26 +1,94 @@
-body article {
-    width: 100%;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    -webkit-transform: translate(-50%, -50%);
-    transform: translate(-50%, -50%);
+/* Override tufte.css body defaults for centered landing layout */
+body {
+  width: 100%;
+  max-width: 100%;
+  padding-left: 0;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #fafaf8;
 }
 
-section {
-    text-align: center;
+main {
+  text-align: center;
+  max-width: 600px;
+  padding: 3rem 2rem;
+  width: 100%;
 }
 
-section p {
-    width: 100%;
+main h1 {
+  font-size: 3.8rem;
+  font-weight: 400;
+  margin-top: 0;
+  margin-bottom: 0.3rem;
+  letter-spacing: -0.01em;
+  color: #111;
 }
 
-img {
-    padding: 10px;
-    max-width: 70px;
+.subtitle {
+  font-style: italic;
+  font-size: 1.4rem;
+  color: #666;
+  margin: 0.4rem auto 1.8rem;
+  width: 100%;
 }
 
-a:link {
-    background-repeat: none;
-    background: none;
+.bio {
+  font-size: 1.1rem;
+  line-height: 1.75;
+  color: #444;
+  max-width: 480px;
+  margin: 0 auto 2.5rem;
+  width: 100%;
+}
+
+nav {
+  display: flex;
+  gap: 0.9rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+nav a {
+  color: #555;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid #ccc;
+  background: none;
+  text-shadow: none;
+  text-decoration: none;
+}
+
+nav a:hover {
+  color: #111;
+  border-color: #888;
+  background-color: #f0f0ed;
+}
+
+nav a:link,
+nav a:visited {
+  background: none;
+}
+
+@media (max-width: 480px) {
+  main h1 {
+    font-size: 2.8rem;
+  }
+
+  .subtitle {
+    font-size: 1.2rem;
+  }
+
+  nav {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  nav a {
+    width: 160px;
+  }
 }

--- a/tribone/static/css/resume.css
+++ b/tribone/static/css/resume.css
@@ -1,6 +1,31 @@
+.resume-nav {
+    width: 87.5%;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 1.2rem 0 0 12.5%;
+    box-sizing: border-box;
+}
+
+.resume-nav a {
+    font-size: 0.9rem;
+    letter-spacing: 0.04em;
+    color: #888;
+    text-decoration: none;
+    background: none;
+}
+
+.resume-nav a:hover {
+    color: #333;
+}
+
 @media only screen and (max-width: 760px) {
     article {
         padding: 0px;
+    }
+
+    .resume-nav {
+        padding-left: 1rem;
+        width: 100%;
     }
 }
 

--- a/tribone/templates/index.html
+++ b/tribone/templates/index.html
@@ -1,24 +1,23 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Andrew Tribone</title>
-  <style type="text/css">code{white-space: pre;}</style>
   <link rel="stylesheet" href="static/css/tufte.css">
-  <link rel="stylesheet" href="static/css/pandoc.css">
   <link rel="stylesheet" href="static/css/index.css">
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
 </head>
 <body>
-<article>
-<section id="andrew-tribone" class="level1">
-<h1>Andrew Tribone</h1>
-<p><a href="/resume"><img src="/static/img/laugh-solid.svg" alt="resume" /></a> <a href="https://www.github.com/att14"><img src="/static/img/github-square-brands.svg" alt="github" /></a> <a href="https://www.linkedin.com/in/andrew-tribone/"><img src="/static/img/linkedin-brands.svg" alt="linkedin" /></a></p>
-</section>
-</article>
+  <main>
+    <h1>Andrew Tribone</h1>
+    <p class="subtitle">Engineering leader &amp; software architect</p>
+    <p class="bio">Experienced technology leader with a proven track record of building and scaling high-performing engineering teams. Based in Volcano, HI.</p>
+    <nav>
+      <a href="/resume">Resume</a>
+      <a href="https://github.com/att14">GitHub</a>
+      <a href="https://www.linkedin.com/in/andrew-tribone/">LinkedIn</a>
+      <a href="mailto:andrew@trib.one">Email</a>
+    </nav>
+  </main>
 </body>
 </html>

--- a/tribone/templates/markdown/resume.md
+++ b/tribone/templates/markdown/resume.md
@@ -72,13 +72,13 @@ Experienced technology leader with a proven track record of building and scaling
 * Lead project to create a generic data ingestion system from planning to implementation to maintenance.
 * Facilitated Yelp's purchase of Qype by ingesting all company and review data.
 * Enabled partnerships with menu data providers to offer this data on the business pages of Yelp.
-* SUpported Apple Maps integration with differential based data dumps of businesses and reviews using Elastic MapReduce.
+* Supported Apple Maps integration with differential based data dumps of businesses and reviews using Elastic MapReduce.
 
 ## University of Pittsburgh
 ### BS, Computer Science[^P1]
 
 [^H1]: {-} [andrew@trib.one](mailto:andrew@trib.one) [andrew at trib dot one]<br>[<img src="/static/img/linkedin-brands.svg" width=20px height=20px>/in/andrew-tribone](https://www.linkedin.com/in/andrew-tribone/)<br>[<img src="/static/img/github-square-brands.svg" width=20px height=20px>/att14](https://github.com/att14)
-[^C1]: {-} Feburary 2022 — Present<br>Volcano, HI
+[^C1]: {-} February 2022 — Present<br>Volcano, HI
 [^X1]: {-} September 2020 — December 2021<br>Volcano, HI
 [^E4]: {-} February 2020 — August 2020<br>San Francisco, CA
 [^E3]: {-} December 2018 — February 2020<br>San Francisco, CA

--- a/tribone/templates/resume.html
+++ b/tribone/templates/resume.html
@@ -1,19 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Andrew Tribone’s Resume</title>
-  <style type="text/css">code{white-space: pre;}</style>
   <link rel="stylesheet" href="static/css/tufte.css">
   <link rel="stylesheet" href="static/css/pandoc.css">
   <link rel="stylesheet" href="static/css/resume.css">
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
 </head>
 <body>
+<nav class="resume-nav"><a href="/">← Home</a></nav>
 <article>
 <section id="andrew-tribone-h1" class="level1">
 <h1>Andrew Tribone <span class="sidenote-wrapper"><label for="sn-0" class="margin-toggle">&#8853;</label><input type="checkbox" id="sn-0" class="margin-toggle"/><span class="marginnote"><a href="mailto:andrew@trib.one">andrew@trib.one</a> [andrew at trib dot one]<br><a href="https://www.linkedin.com/in/andrew-tribone/"><img src="/static/img/linkedin-brands.svg" width=20px height=20px>/in/andrew-tribone</a><br><a href="https://github.com/att14"><img src="/static/img/github-square-brands.svg" width=20px height=20px>/att14</a><br />
@@ -23,7 +19,7 @@
 <section id="cortex" class="level2">
 <h2>Cortex</h2>
 <section id="principal-software-engineer-c1" class="level3">
-<h3>Principal Software Engineer <span class="sidenote-wrapper"><label for="sn-1" class="margin-toggle">&#8853;</label><input type="checkbox" id="sn-1" class="margin-toggle"/><span class="marginnote">Feburary 2022 — Present<br>Volcano, HI<br />
+<h3>Principal Software Engineer <span class="sidenote-wrapper"><label for="sn-1" class="margin-toggle">&#8853;</label><input type="checkbox" id="sn-1" class="margin-toggle"/><span class="marginnote">February 2022 — Present<br>Volcano, HI<br />
 <br />
 </span></span></h3>
 <ul>
@@ -115,7 +111,7 @@
 <li>Lead project to create a generic data ingestion system from planning to implementation to maintenance.</li>
 <li>Facilitated Yelp’s purchase of Qype by ingesting all company and review data.</li>
 <li>Enabled partnerships with menu data providers to offer this data on the business pages of Yelp.</li>
-<li>SUpported Apple Maps integration with differential based data dumps of businesses and reviews using Elastic MapReduce.</li>
+<li>Supported Apple Maps integration with differential based data dumps of businesses and reviews using Elastic MapReduce.</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
## Summary

- **Landing page redesign** — replaced the bare icon-only page with a proper personal landing page: name in large Spectral type, italic tagline, short bio, and clean text-based nav links (Resume / GitHub / LinkedIn / Email)
- **Resume fixes** — corrected "Feburary" → "February" and "SUpported" → "Supported" in both the rendered HTML and source markdown; added a "← Home" breadcrumb link
- **GitHub Pages deployment** — new `.github/workflows/deploy.yml` that assembles a static site from the Flask templates and assets, writes a `CNAME` for `trib.one`, and deploys via `actions/deploy-pages` on every push to `main`

## Test plan

- [ ] Merge PR → confirm the Actions workflow runs green
- [ ] Visit `trib.one` and confirm the redesigned landing page loads
- [ ] Visit `trib.one/resume` and confirm the resume loads with the "← Home" link and correct spelling
- [ ] Confirm `trib.one/resume.pdf` is accessible

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMj3DdiXYCKnhgc987233N)_